### PR TITLE
Add oh-my-zsh-compatible plugin file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ Have any other ideas/suggestions? [**Hop in to ugit discussions 💬️**](https
 
 ## Installation
 
+### Prerequisites
+
 **ugit** dependencies:
 
 - `Bash`>=3
 - GNU utils like `awk`, `grep`, `tput` etc
 - [fzf](https://github.com/junegunn/fzf) (Install latest version. Minimum required 0.21.0)
 
+### Manual Installation
 
 1. Install the script using `curl`
 
@@ -112,6 +115,39 @@ Have any other ideas/suggestions? [**Hop in to ugit discussions 💬️**](https
    Read the guide: https://bhupesh.gitbook.io/notes/git/how-to-undo-anything-in-git
 
    ```
+
+### ZSH Frameworks
+
+#### Zgenom
+
+If you're using [Zgenom](https://github.com/jandamm/zgenom):
+
+1. Add `zgenom load Bhupesh-V/ugit` to your `.zshrc` along with your other `zgenom load` commands.
+2. `zgenom reset && zgenom save`
+
+#### Antigen
+
+If you're using [Antigen](https://github.com/zsh-users/antigen):
+
+1. Add `antigen bundle Bhupesh-V/ugit` to your `.zshrc` where you've listed your other plugins.
+2. Close and reopen your Terminal/iTerm window to **refresh context** and use the plugin. Alternatively, you can run `antigen bundle Bhupesh-V/ugit` in a running shell to have `antigen` load the new plugin.
+
+#### Oh-My-ZSH
+
+If you're using [oh-my-zsh](github.com/robbyrussell/oh-my-zsh):
+
+1. Clone the repository into a new `git-extra-commands` directory in oh-my-zsh's plugin folder:
+
+    `git clone https://github.com/Bhupesh-V/ugit.git $ZSH_CUSTOM/plugins/ugit`
+
+2. Edit your `~/.zshrc` and add `ugit` – same as clone directory – to the list of plugins to enable:
+
+    `plugins=( ... ugit )`
+
+3. Then, restart your terminal application to **refresh context** and use the plugin. Alternatively, you can source your current shell configuration:
+
+    `source ~/.zshrc`
+
 
 ## `ugit` in ...
 **News**

--- a/ugit.plugin.zsh
+++ b/ugit.plugin.zsh
@@ -1,0 +1,7 @@
+# Copyright 2021 Joseph Block <jpb@unixorn.net>
+#
+# Licensed under the MIT license.
+
+# Append the repo's main directory to $PATH to make ugit available
+PLUGIN_BIN="$(dirname $0)"
+export PATH=${PATH}:${PLUGIN_BIN}


### PR DESCRIPTION
Add `ugit.plugin.zsh`.

This is the standard name used by Oh-My-ZSH (and oh-my-zsh-compatible ZSH frameworks) for plugins, and once added to the user's configuration, will be loaded automatically during login, and add the repo directory to the user's `$PATH` to make `ugit` available.

This is also used by smarter ZSH frameworks like Antigen and Zgenom to automatically keep the user's checkout of `ugit` up to date so they get automatic updates.

Closes #10