### PR TITLE
Update bad git-extra-commands reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ If you're using [Antigen](https://github.com/zsh-users/antigen):
 
 If you're using [oh-my-zsh](github.com/robbyrussell/oh-my-zsh):
 
-1. Clone the repository into a new `git-extra-commands` directory in oh-my-zsh's plugin folder:
+1. Clone the repository into a new `ugit` directory in oh-my-zsh's plugin folder:
 
     `git clone https://github.com/Bhupesh-V/ugit.git $ZSH_CUSTOM/plugins/ugit`
 


### PR DESCRIPTION
When I was copying the installation instructions, I missed a reference to `git-extra-commands`, update.

Sorry about that.