### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ Have any other ideas/suggestions? [**Hop in to ugit discussions 💬️**](https
 
 ### Installation
 
+#### Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `ugit` in just one click.
+
+<a href="https://fig.io/plugins/other/ugit_Bhupesh-V" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 #### Linux
 
 ```bash


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

`ugit` is already listed in the store so we'd love to have it listed as a download method on your README.

Thanks so much and please let me know if you have any questions!