### PR TITLE
Fix: Undo Initial Commit

### DIFF
--- a/ugit
+++ b/ugit
@@ -53,9 +53,14 @@ undo_git_commit() {
     [ -z "$commit" ] && exit
 
     last_commit=$(git log --format="%h" -n 1)
+    initial_commit=$(git rev-list --max-parents=0 --abbrev-commit HEAD)
 
     if [[ "$last_commit" == "$commit" ]]; then
-        if git reset HEAD~; then
+        if [[ "$last_commit" == "$initial_commit" ]]; then
+            if git update-ref -d HEAD && git rm --cached -rf . > /dev/null 2>&1; then
+                printf "%s\nInitial commit: $initial_commit successfully undone. Commit state is clean."
+            fi
+        elif git reset HEAD~; then
             printf "%s\n" "Commit: $last_commit successfully undone"
         fi
     elif git revert "$commit"; then

--- a/ugit
+++ b/ugit
@@ -53,14 +53,9 @@ undo_git_commit() {
     [ -z "$commit" ] && exit
 
     last_commit=$(git log --format="%h" -n 1)
-    initial_commit=$(git rev-list --max-parents=0 --abbrev-commit HEAD)
 
     if [[ "$last_commit" == "$commit" ]]; then
-        if [[ "$last_commit" == "$initial_commit" ]]; then
-            if git update-ref -d HEAD && git rm --cached -rf . > /dev/null 2>&1; then
-                printf "%s\nInitial commit: $initial_commit successfully undone. Commit state is clean."
-            fi
-        elif git reset HEAD~; then
+        if git reset HEAD~; then
             printf "%s\n" "Commit: $last_commit successfully undone"
         fi
     elif git revert "$commit"; then

--- a/ugit
+++ b/ugit
@@ -56,6 +56,8 @@ undo_git_commit() {
     initial_commit=$(git rev-list --max-parents=0 --abbrev-commit HEAD)
 
     if [[ "$last_commit" == "$commit" ]]; then
+        # If the last commit is the same as the initial commit, delete reference to the branch(update-ref) and unstage changes of the initial commit(git rm).
+        # This will not delete the files from your working directory
         if [[ "$last_commit" == "$initial_commit" ]]; then
             if git update-ref -d HEAD && git rm --cached -rf . > /dev/null 2>&1; then
                 printf "%s\nInitial commit: $initial_commit successfully undone. Commit state is clean."


### PR DESCRIPTION
Undo initial commit from Git repo

Objective: 
- Clean commit state 
- Changes made with the **initial commit** are left as **unstaged** changes

Demo:

https://user-images.githubusercontent.com/31576619/184343743-a8191ef5-312a-44d4-ad01-c693d496c33c.mp4

