### PR TITLE
fix: fix `printf` command when undoing initial commit

### DIFF
--- a/ugit
+++ b/ugit
@@ -64,7 +64,7 @@ undo_git_commit() {
         # This will not delete the files from your working directory
         if [[ "$last_commit" == "$initial_commit" ]]; then
             if git update-ref -d HEAD && git rm --cached -rf . > /dev/null 2>&1; then
-                printf "%s\nInitial commit: $initial_commit successfully undone. Commit state is clean."
+                printf "%s\n" "Initial commit: $initial_commit successfully undone. Commit state is clean."
             else
                 perror "Error: Failed to revert initial commit"
                 exit


### PR DESCRIPTION
## What is the current behavior?

When successfully undoing the initial commit, the output is not well formatted.

It currently produces the following output:

```sh
$ printf "%s\nInitial commit: $initial_commit successfully undone. Commit state is clean."

Initial commit:  successfully undone. Commit state is clean.%
```

## What is the new behavior?

The output will be displayed as follows:

```sh
$ printf "%s\n" "Initial commit: $initial_commit successfully undone. Commit state is clean."
Initial commit:  successfully undone. Commit state is clean.
```
