### PR TITLE
Updated Ugit Bash File - Replaced HEREDOC

### DIFF
--- a/ugit
+++ b/ugit
@@ -421,24 +421,18 @@ check_deps() {
 show_version() {
     printf "ugit version %s\n" "$VERSION"
 }
-
 print_help() {
-    cat <<EOF
-Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-v] [-u] [-g]
-
-ugit helps you undo git commands without much effort
-Just run 'ugit' and search for what you want to undo
-
-Available options:
-
--h, --help      Print this help and exit
--v, --version   Print current ugit version
--u, --update    Update ugit
--g, --guide     Open ugit undo text guide
-EOF
-printf "\n%s\n" "Contact 📬️: $(tput bold)varshneybhupesh@gmail.com${RESET} for assistance"
-printf "%s\n" "Read the guide: https://bhupesh.gitbook.io/notes/git/how-to-undo-anything-in-git"
-printf "\n%s\n" "Please give us ⭐ a if you liked ugit ${BOLD_ORG_FG}https://github.com/Bhupesh-V/ugit${RESET}"
+    printf "Usage: %s [-h] [-v] [-u] [-g]\n" "$(basename "${BASH_SOURCE[0]}")"
+    printf "ugit helps you undo git commands without much effort\n"
+    printf "Just run 'ugit' and search for what you want to undo\n\n"
+    printf "Available options:\n"
+    printf "  -h, --help      Print this help and exit\n"
+    printf "  -v, --version   Print current ugit version\n"
+    printf "  -u, --update    Update ugit\n"
+    printf "  -g, --guide     Open ugit undo text guide\n\n"
+    printf "Contact 📬️: %s for assistance\n" "$(tput bold)varshneybhupesh@gmail.com${RESET}"
+    printf "Read the guide: %s\n" "https://bhupesh.gitbook.io/notes/git/how-to-undo-anything-in-git"
+    printf "Please give us ⭐ a if you liked ugit %s\n" "${BOLD_ORG_FG}https://github.com/Bhupesh-V/ugit${RESET}"
 }
 
 get_changelog() {

--- a/ugit
+++ b/ugit
@@ -431,7 +431,7 @@ print_help() {
     printf "  -u, --update    Update ugit\n"
     printf "  -g, --guide     Open ugit undo text guide\n\n"
     printf "Contact 📬️: %s for assistance\n" "$(tput bold)varshneybhupesh@gmail.com${RESET}"
-    printf "Read the guide: %s\n" "https://bhupesh.gitbook.io/notes/git/how-to-undo-anything-in-git"
+    printf "Read the guide: %s\n" "https://til.bhupesh.me/git/how-to-undo-anything-in-git"
     printf "Please give us ⭐ a if you liked ugit %s\n" "${BOLD_ORG_FG}https://github.com/Bhupesh-V/ugit${RESET}"
 }
 

--- a/ugit
+++ b/ugit
@@ -429,7 +429,7 @@ print_help() {
     printf "  -h, --help      Print this help and exit\n"
     printf "  -v, --version   Print current ugit version\n"
     printf "  -u, --update    Update ugit\n"
-    printf "  -g, --guide     Open ugit undo text guide\n\n"
+    printf "  -g, --guide     Open the ugit undo text guide\n\n"
     printf "Contact 📬️: %s for assistance\n" "$(tput bold)varshneybhupesh@gmail.com${RESET}"
     printf "Read the guide: %s\n" "https://til.bhupesh.me/git/how-to-undo-anything-in-git"
     printf "Please give us a ⭐ if you liked ugit %s\n" "${BOLD_ORG_FG}https://github.com/Bhupesh-V/ugit${RESET}"

--- a/ugit
+++ b/ugit
@@ -432,7 +432,7 @@ print_help() {
     printf "  -g, --guide     Open ugit undo text guide\n\n"
     printf "Contact 📬️: %s for assistance\n" "$(tput bold)varshneybhupesh@gmail.com${RESET}"
     printf "Read the guide: %s\n" "https://til.bhupesh.me/git/how-to-undo-anything-in-git"
-    printf "Please give us ⭐ a if you liked ugit %s\n" "${BOLD_ORG_FG}https://github.com/Bhupesh-V/ugit${RESET}"
+    printf "Please give us a ⭐ if you liked ugit %s\n" "${BOLD_ORG_FG}https://github.com/Bhupesh-V/ugit${RESET}"
 }
 
 get_changelog() {


### PR DESCRIPTION
Removed usage of HEREDOC and replaced with preferred "printf" statements for printing "--help" text in the Ugit bash file.
Fixes Issue #67

Initial status of --help text with reliance on "cat" command:

![image](https://github.com/Bhupesh-V/ugit/assets/116681578/7fe40f5c-9437-40ae-8471-8f2353886486)

Current status of --help text replaced with "printf" statements:

![image](https://github.com/Bhupesh-V/ugit/assets/116681578/ccb65dda-f9e5-45f5-a491-f00ea88e1a3b)

Result:

![image](https://github.com/Bhupesh-V/ugit/assets/116681578/579546ae-4b2a-41e9-b939-da1ac4675bdf)

With this change, the following would be achieved:
- Readability: each line of the help text is formatted individually, making it easier to understand.
- Ease of modification: using individual "printf" commands allows for easier modification of those lines without affecting the entire block fo text.
- Consistency: the overall script uses printf in other parts, replacing HEREDOC with printf ensures consistency.
- Avoiding External Commands: eliminates the reliance on the cat command, making the script more self-contained.