### PR TITLE
README.md file update to include the "git-undo" command conflict with git-extra. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ If you're using [oh-my-zsh](github.com/robbyrussell/oh-my-zsh):
 
     `source ~/.zshrc`
 
-## Note on `git-undo` Command Conflict
+### Note on `git-undo` Command Conflict
 
 If you have both `ugit` and `git-extras` (https://github.com/tj/git-extras) installed, be aware that both provide a `git-undo` command. This can lead to conflicts, as only one version of the command will be accessible at a time. To resolve this:
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,15 @@ If you're using [oh-my-zsh](github.com/robbyrussell/oh-my-zsh):
 
     `source ~/.zshrc`
 
+## Note on `git-undo` Command Conflict
+
+If you have both `ugit` and `git-extras` (https://github.com/tj/git-extras) installed, be aware that both provide a `git-undo` command. This can lead to conflicts, as only one version of the command will be accessible at a time. To resolve this:
+
+- **Using Homebrew**: Homebrew will notify you of the conflict during installation. You can choose to unlink the conflicting formula or use the --overwrite flag to force the link as follows:
+
+  `brew link --overwrite ugit`
+
+- **Manual Installation**: Ensure that the `git-undo` command from the desired package is prioritized in your system's PATH. 
 
 
 ## Please read ⚠️


### PR DESCRIPTION
Hey there. 

According to issue #34 there is a symlink conflict with the command "git undo" when having ugit and git-extras installed, since both of them use the same command. In the case where ugit is installed with Homebrew, the user **is** notified since a `conflicts_with` directive has already been included in ugit's formula definition: `conflicts_with "git-extras", because: "both install git-undo binaries" `

However, in other cases the conflict may go unnoticed and git-extras's `git undo` would have priority. If the user wants to specifically use ugit's `git-undo` it would need to manually ensure ugit's path has priority over git-extras. In any case, I thought it would be important to mention the possible overlapping functionality of this packages in the README.md file to ensure a better user experience having a clear documentation on known issues. 

It's a small contribution but I hope it helps! If you have any suggestions on the formatting, content or where this would be better located, let me know. 